### PR TITLE
feat: Replace emoji icons with lucide-react icons in MarketPage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -295,6 +295,33 @@ pnpm dev:server  # Check console output for WebSocket errors
 # Verify CORS settings in server configuration
 ```
 
+**Icons Not Displaying**
+
+When UI icons (especially newly added ones) are not displaying:
+
+```bash
+# Rebuild packages in dependency order
+pnpm --filter @trading-viewer/shared build
+pnpm --filter @trading-viewer/ui build
+
+# Clear cache and restart
+pnpm clean
+pnpm install
+pnpm dev
+
+# Check for missing icon definitions
+# 1. Ensure new icons are added to packages/ui/src/components/Icon.tsx imports
+# 2. Ensure new icons are added to iconMap object
+# 3. For semantic names, ensure they're defined in packages/shared/src/types/ui/icons.ts
+```
+
+**Common causes:**
+
+- Package build dependency issues (shared/ui packages need rebuilding after icon changes)
+- Missing icon imports in lucide-react imports section
+- Missing iconMap entries in UI Icon component
+- Missing COMMON_ICONS definitions in shared package
+
 ### Performance Monitoring
 
 **Bundle Size Analysis**

--- a/apps/client/src/pages/MarketPage.tsx
+++ b/apps/client/src/pages/MarketPage.tsx
@@ -41,13 +41,13 @@ const MarketPage: React.FC = () => {
 
   // Define market categories
   const marketTabs = [
-    { id: 'indices' as MarketTab, label: 'Indices', icon: 'BarChart3' },
-    { id: 'stocks-japan' as MarketTab, label: 'Japan Stocks', icon: '🇯🇵' },
-    { id: 'stocks-world' as MarketTab, label: 'World Stocks', icon: '🌍' },
-    { id: 'crypto' as MarketTab, label: 'Crypto', icon: '₿' },
-    { id: 'futures' as MarketTab, label: 'Futures', icon: 'TrendingUp' },
-    { id: 'fx' as MarketTab, label: 'FX', icon: '💱' },
-    { id: 'bonds' as MarketTab, label: 'Bonds', icon: '🏦' },
+    { id: 'indices' as MarketTab, label: 'Indices', icon: 'chart' },
+    { id: 'stocks-japan' as MarketTab, label: 'Japan Stocks', icon: 'japanStocks' },
+    { id: 'stocks-world' as MarketTab, label: 'World Stocks', icon: 'worldStocks' },
+    { id: 'crypto' as MarketTab, label: 'Crypto', icon: 'crypto' },
+    { id: 'futures' as MarketTab, label: 'Futures', icon: 'trending' },
+    { id: 'fx' as MarketTab, label: 'FX', icon: 'fx' },
+    { id: 'bonds' as MarketTab, label: 'Bonds', icon: 'bonds' },
     { id: 'etf' as MarketTab, label: 'ETF', icon: 'Package' },
     { id: 'economics' as MarketTab, label: 'Economics', icon: 'TrendingDown' },
   ]
@@ -375,7 +375,7 @@ const MarketPage: React.FC = () => {
                       : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300 dark:text-gray-400 dark:hover:text-gray-300'
                   }`}
                 >
-                  <span>{tab.icon}</span>
+                  <Icon name={tab.icon} className='w-4 h-4' />
                   <span>{tab.label}</span>
                 </button>
               ))}
@@ -448,8 +448,9 @@ const MarketPage: React.FC = () => {
                 <div className='grid grid-cols-1 lg:grid-cols-2 gap-8'>
                   {/* Major Currency Pairs */}
                   <div className='bg-white dark:bg-gray-800 rounded-lg shadow p-6'>
-                    <h3 className='text-lg font-semibold text-gray-900 dark:text-white mb-4'>
-                      💱 Major Currency Pairs
+                    <h3 className='text-lg font-semibold text-gray-900 dark:text-white mb-4 flex items-center'>
+                      <Icon name='fx' className='w-5 h-5 mr-2' />
+                      Major Currency Pairs
                     </h3>
                     <div className='grid grid-cols-2 gap-x-4 gap-y-2'>
                       {marketData.slice(0, 6).map(item => (
@@ -483,8 +484,9 @@ const MarketPage: React.FC = () => {
 
                   {/* Cross Currency Pairs */}
                   <div className='bg-white dark:bg-gray-800 rounded-lg shadow p-6'>
-                    <h3 className='text-lg font-semibold text-gray-900 dark:text-white mb-4'>
-                      🔄 Cross Currency Pairs
+                    <h3 className='text-lg font-semibold text-gray-900 dark:text-white mb-4 flex items-center'>
+                      <Icon name='fx' className='w-5 h-5 mr-2' />
+                      Cross Currency Pairs
                     </h3>
                     <div className='grid grid-cols-2 gap-x-4 gap-y-2'>
                       {marketData.slice(6, 12).map(item => (

--- a/packages/shared/src/types/ui/icons.ts
+++ b/packages/shared/src/types/ui/icons.ts
@@ -31,6 +31,12 @@ export const COMMON_ICONS = {
   trending: 'TrendingUp',
   target: 'Target',
   bell: 'Bell',
+  // Market categories
+  japanStocks: 'JapaneseYen',
+  worldStocks: 'Globe',
+  crypto: 'Bitcoin',
+  fx: 'ArrowLeftRight',
+  bonds: 'Landmark',
 
   // User & Auth
   user: 'User',

--- a/packages/ui/src/components/Icon.tsx
+++ b/packages/ui/src/components/Icon.tsx
@@ -88,6 +88,11 @@ import {
   // 絵文字置き換え用アイコン
   Package,
   Lightbulb,
+  JapaneseYen,
+  Globe,
+  Bitcoin,
+  ArrowLeftRight,
+  Landmark,
 } from 'lucide-react'
 
 // アイコンマッピング（Tree-shaking 対応）
@@ -177,6 +182,11 @@ const iconMap = {
   // 絵文字置き換え用アイコン
   Package,
   Lightbulb,
+  JapaneseYen,
+  Globe,
+  Bitcoin,
+  ArrowLeftRight,
+  Landmark,
   // エイリアス対応
   trending: TrendingUp, // 'trending' アイコンを TrendingUp にマップ
   // COMMON_ICONS エイリアス


### PR DESCRIPTION
- Replace emoji icons (🇯🇵, 🌍, ₿, 💱, 🏦) with semantic lucide-react icons
- Add new market category icons to shared types: japanStocks, worldStocks, crypto, fx, bonds
- Update UI Icon component with JapaneseYen, Globe, Bitcoin, ArrowLeftRight, Landmark icons
- Convert emoji-based tab icons to consistent Icon components for unified design language
- Add troubleshooting documentation for icon display issues

🤖 Generated with [Claude Code](https://claude.ai/code)